### PR TITLE
Fix the runpty make target so it depends on the file it builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,22 @@ dialyzer-plt:
 dialyzer:
 	mix dialyzer
 
-runpty: c_src/runpty.c
-	$(CC) -o priv/bin/kleened_pty $(CFLAGS) $(LDFLAGS) $<
+# The rule is on the built file, not on the 'runpty' alias. Naming the target
+# 'runpty' meant no such file ever existed, so make rebuilt the helper on *every*
+# invocation -- and mix.exs registers a :run_pty compiler that calls this on every
+# 'mix compile'. In the dev VM the repo is a 9P share that root cannot write to, so
+# a root-side compile truncated priv/bin/kleened_pty and then failed, leaving no
+# helper at all and every jail-based test failing with exit-code 8.
+# NB: the source is named literally rather than via '$<'. BSD make (FreeBSD's
+# make) only defines '$<' for inference rules, so in an explicit rule it expands
+# to nothing and the compile fails with "no input files".
+priv/bin/kleened_pty: c_src/runpty.c
+	mkdir -p priv/bin
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) c_src/runpty.c
+
+runpty: priv/bin/kleened_pty
 
 clean-runpty:
-	rm -rf priv/bin/runpty
+	rm -f priv/bin/kleened_pty
 
-.PHONY: test dialyzer dialyzer-plt
+.PHONY: test dialyzer dialyzer-plt runpty clean-runpty


### PR DESCRIPTION
Small fix, but it was the root cause of a confusing failure mode.

The rule was named `runpty`, so no such file ever existed and make rebuilt the helper on **every** invocation. `mix.exs` registers a `:run_pty` compiler that calls it on every `mix compile`, so this fired constantly.

That's merely wasteful on a normal checkout, but harmful in the dev VM, where the repo is a 9P share that root cannot write to. A root-side compile *truncated* `priv/bin/kleened_pty` and then failed, leaving no helper at all — after which every jail-based test failed with `exit-code 8`. Nothing in that symptom points at the Makefile.

With the rule on `priv/bin/kleened_pty`, make skips it when up to date, and a root-run `mix` command no longer destroys the binary. Verified: `md5` of the helper is unchanged across a root-run `mix openapi.spec.json`, where it previously vanished.

Also fixes `clean-runpty`, which removed `priv/bin/runpty` — a filename that has never existed.

## One gotcha worth knowing

The source is named literally rather than via `$<`. BSD make (FreeBSD's `make`) only defines `$<` for inference rules, so in an explicit rule it expands to nothing and the build fails with `cc: error: no input files`. The old rule got away with it because `runpty: c_src/runpty.c` happened to be treated as an inference-like case.

## Verification

In the dev VM: `make runpty` builds, a second `make runpty` is a no-op, and the full suite is 141 tests / 1 failure — the single failure being a test that queries `1.1.1.1` directly, which the network this ran on currently blocks. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)