### PR TITLE
Stage 2: add a fast 'unit' test tier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,14 @@ dryinit:
 test:
 	${PTY_PATH} mix test --seed 0 --trace --max-failures 1
 
+# The fast tier: tests tagged :unit, which are pure functions over their inputs.
+# '--no-start' keeps the OTP application down, so no config file, ZFS pool, pf or
+# daemon socket is needed -- this runs on an unprivileged, unprovisioned checkout
+# in a couple of seconds. test_helper.exs skips creating the base image when it
+# sees the run is unit-only.
+test-unit:
+	mix test --no-start --only unit
+
 shell:
 	${PTY_PATH} MIX_ENV=test iex -S mix
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ test:
 
 # The fast tier: tests tagged :unit, which are pure functions over their inputs.
 # '--no-start' keeps the OTP application down, so no config file, ZFS pool, pf or
-# daemon socket is needed -- this runs on an unprivileged, unprovisioned checkout
-# in a couple of seconds. test_helper.exs skips creating the base image when it
+# daemon socket is needed. test_helper.exs skips creating the base image when it
 # sees the run is unit-only.
 test-unit:
 	mix test --no-start --only unit

--- a/test/dockerfile_test.exs
+++ b/test/dockerfile_test.exs
@@ -3,6 +3,8 @@ defmodule DockerfileTest do
   use ExUnit.Case
 
   @moduletag :capture_log
+  # Pure functions: no jails, ZFS, pf or daemon. Part of the fast 'unit' tier.
+  @moduletag :unit
 
   test "from instruction" do
     test1 = parse("# Testing\nFROM lol\n# One more comment")

--- a/test/engine_utils_test.exs
+++ b/test/engine_utils_test.exs
@@ -3,6 +3,8 @@ defmodule CoreUtilsTest do
   alias Kleened.Core.Utils
 
   @moduletag :capture_log
+  # Pure functions: no jails, ZFS, pf or daemon. Part of the fast 'unit' tier.
+  @moduletag :unit
 
   test "test duration_to_human_string(now, from)" do
     assert "Less than a second" == Utils.duration_to_human_string(10, 10)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,7 +17,13 @@ ExUnit.configure(
   max_failures: 1
 )
 
-Kleened.Test.Utils.create_test_base_image()
+# Creating the base image needs the running application, and hence ZFS and root.
+# Keyed off whether the supervision tree is actually up rather than off a flag:
+# 'mix test --no-start' leaves it down, which is how the fast :unit tier runs on an
+# unprivileged, unprovisioned checkout.
+if Process.whereis(Kleened.Core.Config) != nil do
+  Kleened.Test.Utils.create_test_base_image()
+end
 
 defmodule TestHelper do
   import ExUnit.Assertions


### PR DESCRIPTION
Only **8 of kleened's 141 tests** are pure functions over their inputs; the rest need FreeBSD, root, ZFS, jails, pf and a provisioned host. There was no way to run just those 8 — the only selection granularity was file or `file:line` — so checking a pure-logic change cost a full two-minute system run against a prepared VM.

```
make test-unit    8 tests, 0.8s, unprivileged, no daemon
```

## How

- `@moduletag :unit` on `dockerfile_test.exs` and `engine_utils_test.exs`.
- A `test-unit` target running `mix test --no-start --only unit`. **`--no-start`** is the important part: it keeps the OTP application down, so no config file, ZFS pool, pf or daemon socket is needed.
- `test_helper.exs` created the `FreeBSD:testing` base image unconditionally at load time, which needs the running application. That's now conditional on the supervision tree actually being up.

On that last point — I first keyed it off `ExUnit.configuration()[:include]` containing `{:unit, true}`, but the `--only` flag isn't reflected there by the time `test_helper.exs` runs. Keying off `Process.whereis(Kleened.Core.Config)` instead ties the behaviour to the actual precondition rather than to a flag, so it stays correct however the run is invoked.

## Verification

- `make test-unit`: 8 tests, 0 failures, 0.8 s (133 excluded), as an unprivileged user with no daemon running.
- `make test` (system tier): 141 tests, 0 failures — unchanged.

Companion PRs: klee (`test-unit` plus the first pure-function tests) and kleene-dev (a combined target across both projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)