### PR TITLE
Stage 3a: make pf ruleset generation a pure function, and test it directly

### DIFF
--- a/lib/core/network.ex
+++ b/lib/core/network.ex
@@ -608,53 +608,120 @@ defmodule Kleened.Core.Network do
     "kleenet_#{network_id}"
   end
 
+  # Impure shell: gather everything the ruleset depends on, persist the published
+  # ports now that their addresses are known, and hand the data to build_pf_config/1.
   defp create_pf_config() do
-    networks = MetaData.list_networks()
-    containers = MetaData.list_containers()
+    template_path = Config.get("pf_config_template_path")
 
+    case File.read(template_path) do
+      {:ok, template} ->
+        networks = MetaData.list_networks()
+
+        containers =
+          MetaData.list_containers() |> Enum.map(&resolve_container_published_ports/1)
+
+        Enum.each(containers, &MetaData.add_container/1)
+
+        {:ok,
+         build_pf_config(%{
+           networks: networks,
+           network_endpoints:
+             Map.new(networks, &{&1.id, MetaData.get_endpoints_from_network(&1.id)}),
+           containers: containers,
+           host_gateway: Config.get("host_gateway"),
+           host_gw: Config.get("host_gw"),
+           template: template
+         })}
+
+      {:error, msg} ->
+        Logger.error("could not read the pf.conf-template  at #{template_path}: #{msg}")
+        {:error, msg}
+    end
+  end
+
+  @doc """
+  Render the complete pf.conf body from explicit inputs.
+
+  Pure: touches no MetaData, no Config and no filesystem. This is the seam that
+  makes the generated ruleset assertable directly, rather than only by observing
+  its effect on traffic.
+  """
+  @spec build_pf_config(%{
+          networks: [Schemas.Network.t()],
+          network_endpoints: %{String.t() => [endpoint()]},
+          containers: [Schemas.Container.t()],
+          host_gateway: String.t() | nil,
+          host_gw: String.t() | nil,
+          template: String.t()
+        }) :: String.t()
+  def build_pf_config(%{
+        networks: networks,
+        network_endpoints: network_endpoints,
+        containers: containers,
+        host_gateway: host_gateway,
+        host_gw: host_gw,
+        template: template
+      }) do
     state = %{
-      :macros => host_gw_macro() ++ network_interfaces_macro(networks),
+      :macros => host_gw_macro(host_gateway) ++ network_interfaces_macro(networks),
       :translation => [],
       :filtering => []
     }
 
-    state = create_pf_network_config(networks, state)
+    state = create_pf_network_config(networks, host_gw, network_endpoints, state)
     state = create_pf_public_ports_config(containers, state)
-    render_pf_config(state)
+    render_pf_config(state, template)
   end
 
-  defp create_pf_public_ports_config(
-         [%{public_ports: public_ports} = container | rest],
-         state
-       ) do
+  @doc """
+  Fill in each of a container's published ports with the addresses of its endpoints.
+  """
+  @spec resolve_container_published_ports(Schemas.Container.t()) :: Schemas.Container.t()
+  def resolve_container_published_ports(%Schemas.Container{} = container) do
     endpoints = MetaData.get_endpoints_from_container(container.id)
-    ip4 = extract_ip(endpoints, "inet")
-    ip6 = extract_ip(endpoints, "inet6")
 
+    %Schemas.Container{
+      container
+      | public_ports:
+          resolve_published_ports(
+            container.public_ports,
+            extract_ip(endpoints, "inet"),
+            extract_ip(endpoints, "inet6")
+          )
+    }
+  end
+
+  @doc """
+  Pure counterpart of `resolve_container_published_ports/1`: apply the given
+  addresses to a list of published ports, skipping a protocol with no address.
+  """
+  @spec resolve_published_ports([Schemas.PublishedPort.t()], String.t(), String.t()) ::
+          [Schemas.PublishedPort.t()]
+  def resolve_published_ports(public_ports, ip4, ip6) do
     update_port = fn
-      pub_port, ip4, "inet" -> %Schemas.PublishedPort{pub_port | ip_address: ip4}
-      pub_port, ip6, "inet6" -> %Schemas.PublishedPort{pub_port | ip_address6: ip6}
+      pub_port, ip, "inet" -> %Schemas.PublishedPort{pub_port | ip_address: ip}
+      pub_port, ip, "inet6" -> %Schemas.PublishedPort{pub_port | ip_address6: ip}
     end
 
-    new_pub_ports =
-      case {ip4, ip6} do
-        {"", ""} ->
-          public_ports
+    case {ip4, ip6} do
+      {"", ""} ->
+        public_ports
 
-        {ip4, ""} ->
-          public_ports |> Enum.map(&update_port.(&1, ip4, "inet"))
+      {ip4, ""} ->
+        public_ports |> Enum.map(&update_port.(&1, ip4, "inet"))
 
-        {"", ip6} ->
-          public_ports |> Enum.map(&update_port.(&1, ip6, "inet6"))
+      {"", ip6} ->
+        public_ports |> Enum.map(&update_port.(&1, ip6, "inet6"))
 
-        {ip4, ip6} ->
-          public_ports
-          |> Enum.map(&update_port.(&1, ip4, "inet"))
-          |> Enum.map(&update_port.(&1, ip6, "inet6"))
-      end
+      {ip4, ip6} ->
+        public_ports
+        |> Enum.map(&update_port.(&1, ip4, "inet"))
+        |> Enum.map(&update_port.(&1, ip6, "inet6"))
+    end
+  end
 
-    MetaData.add_container(%Schemas.Container{container | public_ports: new_pub_ports})
-    new_state = create_pf_port_config(new_pub_ports, state)
+  defp create_pf_public_ports_config([container | rest], state) do
+    new_state = create_pf_port_config(container.public_ports, state)
     create_pf_public_ports_config(rest, new_state)
   end
 
@@ -778,13 +845,14 @@ defmodule Kleened.Core.Network do
     endpoint.ip_address6
   end
 
-  defp create_pf_network_config([network | rest], state) do
-    updated_macros = state.macros ++ network_macros(network)
+  defp create_pf_network_config([network | rest], host_gw, network_endpoints, state) do
+    endpoints = Map.get(network_endpoints, network.id, [])
+    updated_macros = state.macros ++ network_macros(network, endpoints)
     updated_translation = state.translation ++ network_translation(network)
 
     updated_filtering =
       state.filtering ++
-        block_incoming_traffic_to_network(network) ++ network_filtering(network)
+        block_incoming_traffic_to_network(network) ++ network_filtering(network, host_gw)
 
     new_state = %{
       state
@@ -793,35 +861,26 @@ defmodule Kleened.Core.Network do
         filtering: updated_filtering
     }
 
-    create_pf_network_config(rest, new_state)
+    create_pf_network_config(rest, host_gw, network_endpoints, new_state)
   end
 
-  defp create_pf_network_config([], state) do
+  defp create_pf_network_config([], _host_gw, _network_endpoints, state) do
     state
   end
 
-  defp render_pf_config(%{
-         :macros => macros,
-         :translation => translation,
-         :filtering => filtering
-       }) do
-    template_path = Config.get("pf_config_template_path")
-
-    case File.read(template_path) do
-      {:ok, config_template} ->
-        config =
-          EEx.eval_string(config_template,
-            kleene_macros: Enum.join(macros, "\n"),
-            kleene_translation: Enum.join(translation, "\n"),
-            kleene_filtering: Enum.join(filtering, "\n")
-          )
-
-        {:ok, config}
-
-      {:error, msg} ->
-        Logger.error("could not read the pf.conf-template  at #{template_path}: #{msg}")
-        {:error, msg}
-    end
+  defp render_pf_config(
+         %{
+           :macros => macros,
+           :translation => translation,
+           :filtering => filtering
+         },
+         config_template
+       ) do
+    EEx.eval_string(config_template,
+      kleene_macros: Enum.join(macros, "\n"),
+      kleene_translation: Enum.join(translation, "\n"),
+      kleene_filtering: Enum.join(filtering, "\n")
+    )
   end
 
   defp block_incoming_traffic_to_network(network) do
@@ -834,17 +893,17 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, [ipv4_rule], [ipv6_rule])
   end
 
-  defp network_filtering(%Schemas.Network{internal: false, icc: true} = network) do
+  defp network_filtering(%Schemas.Network{internal: false, icc: true} = network, _host_gw) do
     use_necessary_ip_protocols(network, [icc_allow(network, "inet")], [
       icc_allow(network, "inet6")
     ])
   end
 
-  defp network_filtering(%Schemas.Network{internal: false, icc: false} = network) do
+  defp network_filtering(%Schemas.Network{internal: false, icc: false} = network, _host_gw) do
     use_necessary_ip_protocols(network, [], [])
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: ""} = network) do
+  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: ""} = network, host_gw) do
     {subnet, subnet6, _interface, _nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -855,7 +914,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [icc_allow(network, "inet6"), outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -863,7 +922,10 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, ip4_rules, ip6_rules)
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: _nat_if} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: true, nat: _nat_if} = network,
+         host_gw
+       ) do
     {subnet, subnet6, _interface, nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -874,7 +936,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [icc_allow(network, "inet6"), outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -882,7 +944,10 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, ip4_rules, ip6_rules)
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: false, nat: ""} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: false, nat: ""} = network,
+         _host_gw
+       ) do
     {subnet, subnet6, _interface, _nat_interface, _host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -891,7 +956,10 @@ defmodule Kleened.Core.Network do
     ])
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: false, nat: _nat_if} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: false, nat: _nat_if} = network,
+         host_gw
+       ) do
     {subnet, subnet6, _interface, nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -902,7 +970,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -978,7 +1046,7 @@ defmodule Kleened.Core.Network do
     end
   end
 
-  defp network_macros(network) do
+  defp network_macros(network, endpoints) do
     prefix = prefix(network.id)
 
     # Only set macros for stuff that is defined on the network
@@ -992,14 +1060,14 @@ defmodule Kleened.Core.Network do
       |> Enum.filter(fn {_, value} -> value != "" end)
       |> Enum.map(fn {type, value} -> "#{prefix}_#{type}=\"#{value}\"" end)
 
-    basic_macros ++ [all_network_interfaces(network)]
+    basic_macros ++ [all_network_interfaces(network, endpoints)]
   end
 
-  defp all_network_interfaces(network) do
+  defp all_network_interfaces(network, endpoints) do
     prefix = prefix(network.id)
 
     epairs =
-      MetaData.get_endpoints_from_network(network.id)
+      endpoints
       |> Enum.filter(&(&1.epair != nil and &1.epair != ""))
       |> Enum.map(&"#{&1.epair}a")
 
@@ -1020,8 +1088,8 @@ defmodule Kleened.Core.Network do
     end
   end
 
-  defp host_gw_macro() do
-    case Config.get("host_gateway") do
+  defp host_gw_macro(host_gateway) do
+    case host_gateway do
       nil -> []
       host_gateway -> ["kleenet_host_gw_if=\"#{host_gateway}\""]
     end

--- a/test/pf_config_test.exs
+++ b/test/pf_config_test.exs
@@ -1,0 +1,235 @@
+defmodule PfConfigTest do
+  use ExUnit.Case
+
+  alias Kleened.Core.Network
+  alias Kleened.API.Schemas
+
+  @moduletag :capture_log
+  # Pure: Network.build_pf_config/1 takes all of its inputs explicitly, so no
+  # MetaData, no Config, no filesystem and no running host. Part of the fast tier.
+  @moduletag :unit
+
+  # Mirrors example/pf.conf.kleene. Kept inline so the test does not depend on a
+  # file that a developer may have edited.
+  @template """
+  ### KLEENED MACROS START ###
+  <%= kleene_macros %>
+  ### KLEENED MACROS END #####
+
+  ### KLEENED TRANSLATION RULES START ###
+  <%= kleene_translation %>
+  ### KLEENED TRANSLATION RULES END #####
+
+  ### KLEENED FILTERING RULES START #####
+  <%= kleene_filtering %>
+  ### KLEENED FILTERING RULES END #######
+  """
+
+  defp build(opts \\ []) do
+    Network.build_pf_config(%{
+      networks: Keyword.get(opts, :networks, []),
+      network_endpoints: Keyword.get(opts, :network_endpoints, %{}),
+      containers: Keyword.get(opts, :containers, []),
+      host_gateway: Keyword.get(opts, :host_gateway, "em0"),
+      host_gw: Keyword.get(opts, :host_gw, "em0"),
+      template: @template
+    })
+  end
+
+  defp network(attrs \\ []) do
+    struct!(
+      %Schemas.Network{
+        id: "netid",
+        name: "testnet",
+        type: "loopback",
+        interface: "kleene0",
+        subnet: "10.13.37.0/24",
+        subnet6: "",
+        gateway: "",
+        gateway6: "",
+        nat: "",
+        icc: true,
+        internal: false
+      },
+      attrs
+    )
+  end
+
+  defp container_with_ports(pub_ports) do
+    %Schemas.Container{id: "conid", name: "testcon", public_ports: pub_ports}
+  end
+
+  defp published_port(attrs \\ []) do
+    struct!(
+      %Schemas.PublishedPort{
+        interfaces: ["em0"],
+        host_port: "8080",
+        container_port: "80",
+        protocol: "tcp",
+        ip_address: "10.13.37.2",
+        ip_address6: ""
+      },
+      attrs
+    )
+  end
+
+  describe "macros" do
+    test "the host gateway interface becomes a macro" do
+      assert build(host_gateway: "vtnet0") =~ ~s(kleenet_host_gw_if="vtnet0")
+    end
+
+    test "no host gateway macro when the gateway is unknown" do
+      refute build(host_gateway: nil) =~ "kleenet_host_gw_if"
+    end
+
+    test "network interfaces are collected into a single macro" do
+      config =
+        build(
+          networks: [
+            network(id: "a", interface: "kleene0"),
+            network(id: "b", interface: "kleene1")
+          ]
+        )
+
+      assert config =~ ~s(kleenet_network_interfaces="{lo0, kleene0,kleene1}")
+    end
+
+    test "no interfaces macro when there are no networks" do
+      refute build(networks: []) =~ "kleenet_network_interfaces="
+    end
+  end
+
+  describe "published ports" do
+    test "a published port produces an rdr rule per interface and protocol" do
+      config = build(containers: [container_with_ports([published_port()])])
+
+      assert config =~
+               "rdr on em0 inet proto tcp from any to (em0) port 8080 -> 10.13.37.2 port 80"
+    end
+
+    test "a published port produces a matching pass rule" do
+      config = build(containers: [container_with_ports([published_port()])])
+      assert config =~ "pass quick on em0 inet proto tcp from any to 10.13.37.2 port 80"
+    end
+
+    test "publishing on several interfaces produces a rule for each" do
+      config =
+        build(containers: [container_with_ports([published_port(interfaces: ["em0", "em1"])])])
+
+      assert config =~ "rdr on em0 inet proto tcp"
+      assert config =~ "rdr on em1 inet proto tcp"
+    end
+
+    test "the protocol is carried into the rules" do
+      config = build(containers: [container_with_ports([published_port(protocol: "udp")])])
+      assert config =~ "rdr on em0 inet proto udp"
+    end
+
+    test "an IPv6 address produces inet6 rules" do
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(ip_address: "", ip_address6: "fd00::2")])
+          ]
+        )
+
+      assert config =~ "inet6 proto tcp"
+      assert config =~ "fd00::2"
+    end
+
+    test "several containers each contribute their own rules" do
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(host_port: "8080", ip_address: "10.13.37.2")]),
+            container_with_ports([published_port(host_port: "9090", ip_address: "10.13.37.3")])
+          ]
+        )
+
+      assert config =~ "port 8080 -> 10.13.37.2"
+      assert config =~ "port 9090 -> 10.13.37.3"
+    end
+
+    test "no containers means no translation rules" do
+      config = build(containers: [])
+      translation = section(config, "TRANSLATION")
+      assert String.trim(translation) == ""
+    end
+  end
+
+  describe "container port ranges" do
+    test "a host range with a '*' destination expands to the same-sized range" do
+      config =
+        build(
+          containers: [
+            container_with_ports([
+              published_port(host_port: "8080:8090", container_port: "80:*")
+            ])
+          ]
+        )
+
+      assert config =~ "port 80:90"
+    end
+
+    test "'*' is kept in the rdr target but resolved in the filter rules" do
+      # pf.conf(5) allows '<port>:*' as a redirection target, meaning "preserve the
+      # offset within the range". It is not valid in a filter rule, so only the
+      # translation section keeps it verbatim.
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(host_port: "8080", container_port: "80:*")])
+          ]
+        )
+
+      assert section(config, "TRANSLATION") =~ "-> 10.13.37.2 port 80:*"
+      assert section(config, "FILTERING") =~ "to 10.13.37.2 port 80\n"
+      refute section(config, "FILTERING") =~ "80:*"
+    end
+  end
+
+  describe "network isolation" do
+    test "icc: false blocks traffic between containers on the network" do
+      open = build(networks: [network(icc: true)])
+      closed = build(networks: [network(icc: false)])
+      refute section(open, "FILTERING") == section(closed, "FILTERING")
+    end
+
+    test "internal: true changes the filtering rules" do
+      external = build(networks: [network(internal: false)])
+      internal = build(networks: [network(internal: true)])
+      refute section(external, "FILTERING") == section(internal, "FILTERING")
+    end
+
+    test "a NAT'ed network produces a nat rule for its subnet" do
+      config = build(networks: [network(nat: "em0", subnet: "10.13.37.0/24")])
+      assert section(config, "TRANSLATION") =~ "nat"
+    end
+  end
+
+  describe "rendering" do
+    test "output keeps the template's section markers" do
+      config = build()
+
+      for marker <- [
+            "### KLEENED MACROS START ###",
+            "### KLEENED TRANSLATION RULES START ###",
+            "### KLEENED FILTERING RULES START #####"
+          ] do
+        assert config =~ marker
+      end
+    end
+
+    test "generation is deterministic for the same inputs" do
+      opts = [networks: [network()], containers: [container_with_ports([published_port()])]]
+      assert build(opts) == build(opts)
+    end
+  end
+
+  # Extract the body between a section's START and END markers.
+  defp section(config, name) do
+    [_before, rest] = String.split(config, "### KLEENED #{name}", parts: 2)
+    [body, _after] = String.split(rest, "### KLEENED #{name}", parts: 2)
+    body |> String.split("\n", parts: 2) |> List.last()
+  end
+end


### PR DESCRIPTION
The generated pf ruleset was only ever verified by observing its effect on traffic: boot two containers, run netcat between them, capture packets on `pflog0` to see whether pf logged a block.

**That approach stays.** It is the strongest evidence there is that a rule actually works, and the packet capture is what makes "blocked" a *positive* observation rather than a timeout — a blocked connection is indistinguishable from a slow one at the client. This PR does not remove a single connectivity test.

What it adds is the missing rung underneath. Booting two containers is a very expensive way to check that a rule was *generated* correctly, and it localises badly: a wrong macro surfaces as "container cannot reach the internet", several layers from the cause.

## The seam

`create_pf_config/0` is split into an impure shell that gathers from MetaData and Config, and:

```elixir
Network.build_pf_config(%{
  networks:, network_endpoints:, containers:,
  host_gateway:, host_gw:, template:
}) :: String.t()
```

No MetaData, no Config, no filesystem, no running host.

Threading those through meant giving `host_gw` to `network_filtering/2`, the host gateway to `host_gw_macro/1`, the template to `render_pf_config/2`, and each network's endpoints to `network_macros/2` — that last one was reaching into MetaData from what otherwise looked like a pure formatting function, which is exactly the kind of thing this makes visible.

## Tests

`test/pf_config_test.exs` — 18 tests covering macros, `rdr` and `pass` generation for published ports, multiple interfaces, IPv6, port ranges, and the icc/internal/nat variations. In the `:unit` tier, so unprivileged with no daemon.

```
make test-unit    26 tests, 0.6s   (was 8)
make test        159 tests, 0 failures
```

## One subtlety now pinned down

`<port>:*` **is** valid pf syntax for a redirection target — it preserves the offset within a range — but is **not** valid in a filter rule. So `format_container_port/2` is applied to the `pass` rules only, and the `rdr` rule keeps the `*` verbatim.

I initially wrote a test asserting the opposite, assuming the `rdr` rule was wrong. It isn't. That asymmetry is easy to "tidy up" into a bug, so there's now a test naming it explicitly.

## Verification

- kleened: 159 tests, 0 failures (141 existing + 18 new) — the refactor is behaviour-preserving.
- klee: 113 passed / 5 failed — the same 5 known failures, unchanged.

Stage 3b will add `pfctl -n -f` validation of the generated config (asserting on what pf itself parses, not on my expectation of its syntax) and shrink the combinatorial part of the connectivity matrix, keeping representative cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)