### PR TITLE
Stage 3b: validate generated rulesets against pf itself

### DIFF
--- a/lib/core/network.ex
+++ b/lib/core/network.ex
@@ -642,9 +642,7 @@ defmodule Kleened.Core.Network do
   @doc """
   Render the complete pf.conf body from explicit inputs.
 
-  Pure: touches no MetaData, no Config and no filesystem. This is the seam that
-  makes the generated ruleset assertable directly, rather than only by observing
-  its effect on traffic.
+  Pure: touches no MetaData, no Config and no filesystem.
   """
   @spec build_pf_config(%{
           networks: [Schemas.Network.t()],

--- a/lib/core/network.ex
+++ b/lib/core/network.ex
@@ -1076,16 +1076,19 @@ defmodule Kleened.Core.Network do
     "#{prefix}_all_interfaces=\"{#{all_interfaces}}\""
   end
 
+  # Always defined, even with no networks. The filter rules generated for a
+  # container's published ports reference this macro unconditionally, and pf
+  # rejects the *entire* ruleset if a referenced macro is undefined -- so a
+  # container publishing a port while no network exists used to produce a config
+  # that would not load at all.
+  defp network_interfaces_macro([]) do
+    ["kleenet_network_interfaces=\"{lo0}\""]
+  end
+
   defp network_interfaces_macro(networks) do
-    case length(networks) do
-      0 ->
-        []
+    interfaces = Enum.map(networks, & &1.interface) |> Enum.join(",")
 
-      _ ->
-        interfaces = Enum.map(networks, & &1.interface) |> Enum.join(",")
-
-        ["kleenet_network_interfaces=\"{lo0, #{interfaces}}\""]
-    end
+    ["kleenet_network_interfaces=\"{lo0, #{interfaces}}\""]
   end
 
   defp host_gw_macro(host_gateway) do

--- a/lib/core/network.ex
+++ b/lib/core/network.ex
@@ -608,53 +608,120 @@ defmodule Kleened.Core.Network do
     "kleenet_#{network_id}"
   end
 
+  # Impure shell: gather everything the ruleset depends on, persist the published
+  # ports now that their addresses are known, and hand the data to build_pf_config/1.
   defp create_pf_config() do
-    networks = MetaData.list_networks()
-    containers = MetaData.list_containers()
+    template_path = Config.get("pf_config_template_path")
 
+    case File.read(template_path) do
+      {:ok, template} ->
+        networks = MetaData.list_networks()
+
+        containers =
+          MetaData.list_containers() |> Enum.map(&resolve_container_published_ports/1)
+
+        Enum.each(containers, &MetaData.add_container/1)
+
+        {:ok,
+         build_pf_config(%{
+           networks: networks,
+           network_endpoints:
+             Map.new(networks, &{&1.id, MetaData.get_endpoints_from_network(&1.id)}),
+           containers: containers,
+           host_gateway: Config.get("host_gateway"),
+           host_gw: Config.get("host_gw"),
+           template: template
+         })}
+
+      {:error, msg} ->
+        Logger.error("could not read the pf.conf-template  at #{template_path}: #{msg}")
+        {:error, msg}
+    end
+  end
+
+  @doc """
+  Render the complete pf.conf body from explicit inputs.
+
+  Pure: touches no MetaData, no Config and no filesystem. This is the seam that
+  makes the generated ruleset assertable directly, rather than only by observing
+  its effect on traffic.
+  """
+  @spec build_pf_config(%{
+          networks: [Schemas.Network.t()],
+          network_endpoints: %{String.t() => [endpoint()]},
+          containers: [Schemas.Container.t()],
+          host_gateway: String.t() | nil,
+          host_gw: String.t() | nil,
+          template: String.t()
+        }) :: String.t()
+  def build_pf_config(%{
+        networks: networks,
+        network_endpoints: network_endpoints,
+        containers: containers,
+        host_gateway: host_gateway,
+        host_gw: host_gw,
+        template: template
+      }) do
     state = %{
-      :macros => host_gw_macro() ++ network_interfaces_macro(networks),
+      :macros => host_gw_macro(host_gateway) ++ network_interfaces_macro(networks),
       :translation => [],
       :filtering => []
     }
 
-    state = create_pf_network_config(networks, state)
+    state = create_pf_network_config(networks, host_gw, network_endpoints, state)
     state = create_pf_public_ports_config(containers, state)
-    render_pf_config(state)
+    render_pf_config(state, template)
   end
 
-  defp create_pf_public_ports_config(
-         [%{public_ports: public_ports} = container | rest],
-         state
-       ) do
+  @doc """
+  Fill in each of a container's published ports with the addresses of its endpoints.
+  """
+  @spec resolve_container_published_ports(Schemas.Container.t()) :: Schemas.Container.t()
+  def resolve_container_published_ports(%Schemas.Container{} = container) do
     endpoints = MetaData.get_endpoints_from_container(container.id)
-    ip4 = extract_ip(endpoints, "inet")
-    ip6 = extract_ip(endpoints, "inet6")
 
+    %Schemas.Container{
+      container
+      | public_ports:
+          resolve_published_ports(
+            container.public_ports,
+            extract_ip(endpoints, "inet"),
+            extract_ip(endpoints, "inet6")
+          )
+    }
+  end
+
+  @doc """
+  Pure counterpart of `resolve_container_published_ports/1`: apply the given
+  addresses to a list of published ports, skipping a protocol with no address.
+  """
+  @spec resolve_published_ports([Schemas.PublishedPort.t()], String.t(), String.t()) ::
+          [Schemas.PublishedPort.t()]
+  def resolve_published_ports(public_ports, ip4, ip6) do
     update_port = fn
-      pub_port, ip4, "inet" -> %Schemas.PublishedPort{pub_port | ip_address: ip4}
-      pub_port, ip6, "inet6" -> %Schemas.PublishedPort{pub_port | ip_address6: ip6}
+      pub_port, ip, "inet" -> %Schemas.PublishedPort{pub_port | ip_address: ip}
+      pub_port, ip, "inet6" -> %Schemas.PublishedPort{pub_port | ip_address6: ip}
     end
 
-    new_pub_ports =
-      case {ip4, ip6} do
-        {"", ""} ->
-          public_ports
+    case {ip4, ip6} do
+      {"", ""} ->
+        public_ports
 
-        {ip4, ""} ->
-          public_ports |> Enum.map(&update_port.(&1, ip4, "inet"))
+      {ip4, ""} ->
+        public_ports |> Enum.map(&update_port.(&1, ip4, "inet"))
 
-        {"", ip6} ->
-          public_ports |> Enum.map(&update_port.(&1, ip6, "inet6"))
+      {"", ip6} ->
+        public_ports |> Enum.map(&update_port.(&1, ip6, "inet6"))
 
-        {ip4, ip6} ->
-          public_ports
-          |> Enum.map(&update_port.(&1, ip4, "inet"))
-          |> Enum.map(&update_port.(&1, ip6, "inet6"))
-      end
+      {ip4, ip6} ->
+        public_ports
+        |> Enum.map(&update_port.(&1, ip4, "inet"))
+        |> Enum.map(&update_port.(&1, ip6, "inet6"))
+    end
+  end
 
-    MetaData.add_container(%Schemas.Container{container | public_ports: new_pub_ports})
-    new_state = create_pf_port_config(new_pub_ports, state)
+  defp create_pf_public_ports_config([container | rest], state) do
+    new_state = create_pf_port_config(container.public_ports, state)
     create_pf_public_ports_config(rest, new_state)
   end
 
@@ -778,13 +845,14 @@ defmodule Kleened.Core.Network do
     endpoint.ip_address6
   end
 
-  defp create_pf_network_config([network | rest], state) do
-    updated_macros = state.macros ++ network_macros(network)
+  defp create_pf_network_config([network | rest], host_gw, network_endpoints, state) do
+    endpoints = Map.get(network_endpoints, network.id, [])
+    updated_macros = state.macros ++ network_macros(network, endpoints)
     updated_translation = state.translation ++ network_translation(network)
 
     updated_filtering =
       state.filtering ++
-        block_incoming_traffic_to_network(network) ++ network_filtering(network)
+        block_incoming_traffic_to_network(network) ++ network_filtering(network, host_gw)
 
     new_state = %{
       state
@@ -793,35 +861,26 @@ defmodule Kleened.Core.Network do
         filtering: updated_filtering
     }
 
-    create_pf_network_config(rest, new_state)
+    create_pf_network_config(rest, host_gw, network_endpoints, new_state)
   end
 
-  defp create_pf_network_config([], state) do
+  defp create_pf_network_config([], _host_gw, _network_endpoints, state) do
     state
   end
 
-  defp render_pf_config(%{
-         :macros => macros,
-         :translation => translation,
-         :filtering => filtering
-       }) do
-    template_path = Config.get("pf_config_template_path")
-
-    case File.read(template_path) do
-      {:ok, config_template} ->
-        config =
-          EEx.eval_string(config_template,
-            kleene_macros: Enum.join(macros, "\n"),
-            kleene_translation: Enum.join(translation, "\n"),
-            kleene_filtering: Enum.join(filtering, "\n")
-          )
-
-        {:ok, config}
-
-      {:error, msg} ->
-        Logger.error("could not read the pf.conf-template  at #{template_path}: #{msg}")
-        {:error, msg}
-    end
+  defp render_pf_config(
+         %{
+           :macros => macros,
+           :translation => translation,
+           :filtering => filtering
+         },
+         config_template
+       ) do
+    EEx.eval_string(config_template,
+      kleene_macros: Enum.join(macros, "\n"),
+      kleene_translation: Enum.join(translation, "\n"),
+      kleene_filtering: Enum.join(filtering, "\n")
+    )
   end
 
   defp block_incoming_traffic_to_network(network) do
@@ -834,17 +893,17 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, [ipv4_rule], [ipv6_rule])
   end
 
-  defp network_filtering(%Schemas.Network{internal: false, icc: true} = network) do
+  defp network_filtering(%Schemas.Network{internal: false, icc: true} = network, _host_gw) do
     use_necessary_ip_protocols(network, [icc_allow(network, "inet")], [
       icc_allow(network, "inet6")
     ])
   end
 
-  defp network_filtering(%Schemas.Network{internal: false, icc: false} = network) do
+  defp network_filtering(%Schemas.Network{internal: false, icc: false} = network, _host_gw) do
     use_necessary_ip_protocols(network, [], [])
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: ""} = network) do
+  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: ""} = network, host_gw) do
     {subnet, subnet6, _interface, _nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -855,7 +914,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [icc_allow(network, "inet6"), outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -863,7 +922,10 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, ip4_rules, ip6_rules)
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: true, nat: _nat_if} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: true, nat: _nat_if} = network,
+         host_gw
+       ) do
     {subnet, subnet6, _interface, nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -874,7 +936,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [icc_allow(network, "inet6"), outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -882,7 +944,10 @@ defmodule Kleened.Core.Network do
     use_necessary_ip_protocols(network, ip4_rules, ip6_rules)
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: false, nat: ""} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: false, nat: ""} = network,
+         _host_gw
+       ) do
     {subnet, subnet6, _interface, _nat_interface, _host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -891,7 +956,10 @@ defmodule Kleened.Core.Network do
     ])
   end
 
-  defp network_filtering(%Schemas.Network{internal: true, icc: false, nat: _nat_if} = network) do
+  defp network_filtering(
+         %Schemas.Network{internal: true, icc: false, nat: _nat_if} = network,
+         host_gw
+       ) do
     {subnet, subnet6, _interface, nat_interface, host_gateway_interface} =
       defined_network_macros(network.id)
 
@@ -902,7 +970,7 @@ defmodule Kleened.Core.Network do
     ip6_rules = [outgoing_deny(subnet6), ipv6_internal_nat_rule]
 
     ip6_rules =
-      case Config.get("host_gw") do
+      case host_gw do
         nil -> List.delete_at(ip6_rules, -1)
         _ -> ip6_rules
       end
@@ -978,7 +1046,7 @@ defmodule Kleened.Core.Network do
     end
   end
 
-  defp network_macros(network) do
+  defp network_macros(network, endpoints) do
     prefix = prefix(network.id)
 
     # Only set macros for stuff that is defined on the network
@@ -992,14 +1060,14 @@ defmodule Kleened.Core.Network do
       |> Enum.filter(fn {_, value} -> value != "" end)
       |> Enum.map(fn {type, value} -> "#{prefix}_#{type}=\"#{value}\"" end)
 
-    basic_macros ++ [all_network_interfaces(network)]
+    basic_macros ++ [all_network_interfaces(network, endpoints)]
   end
 
-  defp all_network_interfaces(network) do
+  defp all_network_interfaces(network, endpoints) do
     prefix = prefix(network.id)
 
     epairs =
-      MetaData.get_endpoints_from_network(network.id)
+      endpoints
       |> Enum.filter(&(&1.epair != nil and &1.epair != ""))
       |> Enum.map(&"#{&1.epair}a")
 
@@ -1020,8 +1088,8 @@ defmodule Kleened.Core.Network do
     end
   end
 
-  defp host_gw_macro() do
-    case Config.get("host_gateway") do
+  defp host_gw_macro(host_gateway) do
+    case host_gateway do
       nil -> []
       host_gateway -> ["kleenet_host_gw_if=\"#{host_gateway}\""]
     end

--- a/test/pf_config_test.exs
+++ b/test/pf_config_test.exs
@@ -1,77 +1,12 @@
 defmodule PfConfigTest do
   use ExUnit.Case
 
-  alias Kleened.Core.Network
-  alias Kleened.API.Schemas
+  import Kleened.Test.PfFixtures
 
   @moduletag :capture_log
   # Pure: Network.build_pf_config/1 takes all of its inputs explicitly, so no
   # MetaData, no Config, no filesystem and no running host. Part of the fast tier.
   @moduletag :unit
-
-  # Mirrors example/pf.conf.kleene. Kept inline so the test does not depend on a
-  # file that a developer may have edited.
-  @template """
-  ### KLEENED MACROS START ###
-  <%= kleene_macros %>
-  ### KLEENED MACROS END #####
-
-  ### KLEENED TRANSLATION RULES START ###
-  <%= kleene_translation %>
-  ### KLEENED TRANSLATION RULES END #####
-
-  ### KLEENED FILTERING RULES START #####
-  <%= kleene_filtering %>
-  ### KLEENED FILTERING RULES END #######
-  """
-
-  defp build(opts \\ []) do
-    Network.build_pf_config(%{
-      networks: Keyword.get(opts, :networks, []),
-      network_endpoints: Keyword.get(opts, :network_endpoints, %{}),
-      containers: Keyword.get(opts, :containers, []),
-      host_gateway: Keyword.get(opts, :host_gateway, "em0"),
-      host_gw: Keyword.get(opts, :host_gw, "em0"),
-      template: @template
-    })
-  end
-
-  defp network(attrs \\ []) do
-    struct!(
-      %Schemas.Network{
-        id: "netid",
-        name: "testnet",
-        type: "loopback",
-        interface: "kleene0",
-        subnet: "10.13.37.0/24",
-        subnet6: "",
-        gateway: "",
-        gateway6: "",
-        nat: "",
-        icc: true,
-        internal: false
-      },
-      attrs
-    )
-  end
-
-  defp container_with_ports(pub_ports) do
-    %Schemas.Container{id: "conid", name: "testcon", public_ports: pub_ports}
-  end
-
-  defp published_port(attrs \\ []) do
-    struct!(
-      %Schemas.PublishedPort{
-        interfaces: ["em0"],
-        host_port: "8080",
-        container_port: "80",
-        protocol: "tcp",
-        ip_address: "10.13.37.2",
-        ip_address6: ""
-      },
-      attrs
-    )
-  end
 
   describe "macros" do
     test "the host gateway interface becomes a macro" do
@@ -94,8 +29,10 @@ defmodule PfConfigTest do
       assert config =~ ~s(kleenet_network_interfaces="{lo0, kleene0,kleene1}")
     end
 
-    test "no interfaces macro when there are no networks" do
-      refute build(networks: []) =~ "kleenet_network_interfaces="
+    test "the interfaces macro is defined even with no networks" do
+      # The published-port filter rules reference this macro unconditionally, and
+      # pf rejects the whole ruleset when a referenced macro is undefined.
+      assert build(networks: []) =~ ~s(kleenet_network_interfaces="{lo0}")
     end
   end
 
@@ -189,16 +126,59 @@ defmodule PfConfigTest do
   end
 
   describe "network isolation" do
-    test "icc: false blocks traffic between containers on the network" do
-      open = build(networks: [network(icc: true)])
-      closed = build(networks: [network(icc: false)])
-      refute section(open, "FILTERING") == section(closed, "FILTERING")
+    # The two flags are orthogonal and each contributes exactly one thing:
+    #   icc       -> whether subnet-to-subnet traffic is passed
+    #   internal  -> whether egress off the network is blocked
+    # Asserting the rules directly is what makes it possible to reason about the
+    # combinations without booting a container for each cell.
+    defp filtering(internal, icc) do
+      build(
+        networks: [network(interface: "kleene0", internal: internal, icc: icc, nat: "em0")],
+        host_gw: "em0"
+      )
+      |> section("FILTERING")
     end
 
-    test "internal: true changes the filtering rules" do
-      external = build(networks: [network(internal: false)])
-      internal = build(networks: [network(internal: true)])
-      refute section(external, "FILTERING") == section(internal, "FILTERING")
+    @icc_pass "pass quick on $kleenet_netid_all_interfaces " <>
+                "from $kleenet_netid_subnet to $kleenet_netid_subnet"
+    @egress_block "block out quick log on $kleenet_network_interfaces " <>
+                    "from $kleenet_netid_subnet"
+    @nat_egress_block "block out quick log on $kleenet_netid_nat_if " <>
+                        "from $kleenet_netid_subnet"
+
+    test "incoming traffic to the subnet is always blocked by default" do
+      for internal <- [true, false], icc <- [true, false] do
+        assert filtering(internal, icc) =~ "block in log from any to $kleenet_netid_subnet"
+      end
+    end
+
+    test "icc: true passes traffic between containers on the network" do
+      assert filtering(false, true) =~ @icc_pass
+    end
+
+    test "icc: false omits the inter-container pass rule" do
+      refute filtering(false, false) =~ @icc_pass
+    end
+
+    test "internal: true blocks egress, both generally and via the NAT interface" do
+      rules = filtering(true, true)
+      assert rules =~ @egress_block
+      assert rules =~ @nat_egress_block
+    end
+
+    test "internal: false does not block egress" do
+      rules = filtering(false, true)
+      refute rules =~ @egress_block
+      refute rules =~ @nat_egress_block
+    end
+
+    test "the two flags are independent" do
+      # internal governs egress, icc governs inter-container traffic; neither
+      # should disturb the other.
+      assert filtering(true, false) =~ @egress_block
+      refute filtering(true, false) =~ @icc_pass
+      assert filtering(true, true) =~ @egress_block
+      assert filtering(true, true) =~ @icc_pass
     end
 
     test "a NAT'ed network produces a nat rule for its subnet" do
@@ -224,12 +204,5 @@ defmodule PfConfigTest do
       opts = [networks: [network()], containers: [container_with_ports([published_port()])]]
       assert build(opts) == build(opts)
     end
-  end
-
-  # Extract the body between a section's START and END markers.
-  defp section(config, name) do
-    [_before, rest] = String.split(config, "### KLEENED #{name}", parts: 2)
-    [body, _after] = String.split(rest, "### KLEENED #{name}", parts: 2)
-    body |> String.split("\n", parts: 2) |> List.last()
   end
 end

--- a/test/pf_config_test.exs
+++ b/test/pf_config_test.exs
@@ -1,0 +1,235 @@
+defmodule PfConfigTest do
+  use ExUnit.Case
+
+  alias Kleened.Core.Network
+  alias Kleened.API.Schemas
+
+  @moduletag :capture_log
+  # Pure: Network.build_pf_config/1 takes all of its inputs explicitly, so no
+  # MetaData, no Config, no filesystem and no running host. Part of the fast tier.
+  @moduletag :unit
+
+  # Mirrors example/pf.conf.kleene. Kept inline so the test does not depend on a
+  # file that a developer may have edited.
+  @template """
+  ### KLEENED MACROS START ###
+  <%= kleene_macros %>
+  ### KLEENED MACROS END #####
+
+  ### KLEENED TRANSLATION RULES START ###
+  <%= kleene_translation %>
+  ### KLEENED TRANSLATION RULES END #####
+
+  ### KLEENED FILTERING RULES START #####
+  <%= kleene_filtering %>
+  ### KLEENED FILTERING RULES END #######
+  """
+
+  defp build(opts \\ []) do
+    Network.build_pf_config(%{
+      networks: Keyword.get(opts, :networks, []),
+      network_endpoints: Keyword.get(opts, :network_endpoints, %{}),
+      containers: Keyword.get(opts, :containers, []),
+      host_gateway: Keyword.get(opts, :host_gateway, "em0"),
+      host_gw: Keyword.get(opts, :host_gw, "em0"),
+      template: @template
+    })
+  end
+
+  defp network(attrs \\ []) do
+    struct!(
+      %Schemas.Network{
+        id: "netid",
+        name: "testnet",
+        type: "loopback",
+        interface: "kleene0",
+        subnet: "10.13.37.0/24",
+        subnet6: "",
+        gateway: "",
+        gateway6: "",
+        nat: "",
+        icc: true,
+        internal: false
+      },
+      attrs
+    )
+  end
+
+  defp container_with_ports(pub_ports) do
+    %Schemas.Container{id: "conid", name: "testcon", public_ports: pub_ports}
+  end
+
+  defp published_port(attrs \\ []) do
+    struct!(
+      %Schemas.PublishedPort{
+        interfaces: ["em0"],
+        host_port: "8080",
+        container_port: "80",
+        protocol: "tcp",
+        ip_address: "10.13.37.2",
+        ip_address6: ""
+      },
+      attrs
+    )
+  end
+
+  describe "macros" do
+    test "the host gateway interface becomes a macro" do
+      assert build(host_gateway: "vtnet0") =~ ~s(kleenet_host_gw_if="vtnet0")
+    end
+
+    test "no host gateway macro when the gateway is unknown" do
+      refute build(host_gateway: nil) =~ "kleenet_host_gw_if"
+    end
+
+    test "network interfaces are collected into a single macro" do
+      config =
+        build(
+          networks: [
+            network(id: "a", interface: "kleene0"),
+            network(id: "b", interface: "kleene1")
+          ]
+        )
+
+      assert config =~ ~s(kleenet_network_interfaces="{lo0, kleene0,kleene1}")
+    end
+
+    test "no interfaces macro when there are no networks" do
+      refute build(networks: []) =~ "kleenet_network_interfaces="
+    end
+  end
+
+  describe "published ports" do
+    test "a published port produces an rdr rule per interface and protocol" do
+      config = build(containers: [container_with_ports([published_port()])])
+
+      assert config =~
+               "rdr on em0 inet proto tcp from any to (em0) port 8080 -> 10.13.37.2 port 80"
+    end
+
+    test "a published port produces a matching pass rule" do
+      config = build(containers: [container_with_ports([published_port()])])
+      assert config =~ "pass quick on em0 inet proto tcp from any to 10.13.37.2 port 80"
+    end
+
+    test "publishing on several interfaces produces a rule for each" do
+      config =
+        build(containers: [container_with_ports([published_port(interfaces: ["em0", "em1"])])])
+
+      assert config =~ "rdr on em0 inet proto tcp"
+      assert config =~ "rdr on em1 inet proto tcp"
+    end
+
+    test "the protocol is carried into the rules" do
+      config = build(containers: [container_with_ports([published_port(protocol: "udp")])])
+      assert config =~ "rdr on em0 inet proto udp"
+    end
+
+    test "an IPv6 address produces inet6 rules" do
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(ip_address: "", ip_address6: "fd00::2")])
+          ]
+        )
+
+      assert config =~ "inet6 proto tcp"
+      assert config =~ "fd00::2"
+    end
+
+    test "several containers each contribute their own rules" do
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(host_port: "8080", ip_address: "10.13.37.2")]),
+            container_with_ports([published_port(host_port: "9090", ip_address: "10.13.37.3")])
+          ]
+        )
+
+      assert config =~ "port 8080 -> 10.13.37.2"
+      assert config =~ "port 9090 -> 10.13.37.3"
+    end
+
+    test "no containers means no translation rules" do
+      config = build(containers: [])
+      translation = section(config, "TRANSLATION")
+      assert String.trim(translation) == ""
+    end
+  end
+
+  describe "container port ranges" do
+    test "a host range with a '*' destination expands to the same-sized range" do
+      config =
+        build(
+          containers: [
+            container_with_ports([
+              published_port(host_port: "8080:8090", container_port: "80:*")
+            ])
+          ]
+        )
+
+      assert config =~ "port 80:90"
+    end
+
+    test "'*' is kept in the rdr target but resolved in the filter rules" do
+      # pf.conf(5) allows '<port>:*' as a redirection target, meaning "preserve the
+      # offset within the range". It is not valid in a filter rule, so only the
+      # translation section keeps it verbatim.
+      config =
+        build(
+          containers: [
+            container_with_ports([published_port(host_port: "8080", container_port: "80:*")])
+          ]
+        )
+
+      assert section(config, "TRANSLATION") =~ "-> 10.13.37.2 port 80:*"
+      assert section(config, "FILTERING") =~ "to 10.13.37.2 port 80\n"
+      refute section(config, "FILTERING") =~ "80:*"
+    end
+  end
+
+  describe "network isolation" do
+    test "icc: false blocks traffic between containers on the network" do
+      open = build(networks: [network(icc: true)])
+      closed = build(networks: [network(icc: false)])
+      refute section(open, "FILTERING") == section(closed, "FILTERING")
+    end
+
+    test "internal: true changes the filtering rules" do
+      external = build(networks: [network(internal: false)])
+      internal = build(networks: [network(internal: true)])
+      refute section(external, "FILTERING") == section(internal, "FILTERING")
+    end
+
+    test "a NAT'ed network produces a nat rule for its subnet" do
+      config = build(networks: [network(nat: "em0", subnet: "10.13.37.0/24")])
+      assert section(config, "TRANSLATION") =~ "nat"
+    end
+  end
+
+  describe "rendering" do
+    test "output keeps the template's section markers" do
+      config = build()
+
+      for marker <- [
+            "### KLEENED MACROS START ###",
+            "### KLEENED TRANSLATION RULES START ###",
+            "### KLEENED FILTERING RULES START #####"
+          ] do
+        assert config =~ marker
+      end
+    end
+
+    test "generation is deterministic for the same inputs" do
+      opts = [networks: [network()], containers: [container_with_ports([published_port()])]]
+      assert build(opts) == build(opts)
+    end
+  end
+
+  # Extract the body between a section's START and END markers.
+  defp section(config, name) do
+    [_before, rest] = String.split(config, "### KLEENED #{name}", parts: 2)
+    [body, _after] = String.split(rest, "### KLEENED #{name}", parts: 2)
+    body |> String.split("\n", parts: 2) |> List.last()
+  end
+end

--- a/test/pf_load_test.exs
+++ b/test/pf_load_test.exs
@@ -1,0 +1,171 @@
+defmodule PfLoadTest do
+  @moduledoc """
+  Feed generated rulesets to pf itself.
+
+  `pf_config_test.exs` asserts on the text Kleene produces, which only proves the
+  generator matches *our* idea of pf syntax. These tests hand that text to
+  `pfctl -n -f`, which parses it and prints the ruleset it constructed without
+  loading anything into the kernel. Assertions are therefore on pf's
+  interpretation: macros already expanded, ports canonicalised, pf's own implicit
+  defaults filled in.
+
+  Needs root, because pfctl opens a netlink socket. Needs nothing else -- no
+  jails, no ZFS, no containers, no daemon -- and takes milliseconds.
+  """
+  use ExUnit.Case
+
+  import Kleened.Test.PfFixtures
+
+  @moduletag :capture_log
+
+  # Ports deliberately outside /etc/services: pfctl rewrites well-known numbers to
+  # their service names (80 becomes "http"), which makes assertions confusing.
+  @host_port "15080"
+  @container_port "15081"
+
+  defp pfctl_parse(config) do
+    path = Path.join(System.tmp_dir!(), "kleene_pf_test_#{:erlang.unique_integer([:positive])}")
+    File.write!(path, config)
+
+    try do
+      case System.cmd("/sbin/pfctl", ["-n", "-v", "-f", path], stderr_to_stdout: true) do
+        {output, 0} -> {:ok, output}
+        {output, _} -> {:error, output}
+      end
+    after
+      File.rm(path)
+    end
+  end
+
+  defp assert_parses(config) do
+    case pfctl_parse(config) do
+      {:ok, output} ->
+        output
+
+      {:error, output} ->
+        flunk("pfctl rejected the generated ruleset:\n#{output}\n\nruleset was:\n#{config}")
+    end
+  end
+
+  test "an empty ruleset is valid" do
+    assert_parses(build())
+  end
+
+  test "pfctl accepts a published port and builds the rdr rule we asked for" do
+    output =
+      build(
+        containers: [
+          container_with_ports([
+            published_port(
+              interfaces: ["lo0"],
+              host_port: @host_port,
+              container_port: @container_port
+            )
+          ])
+        ]
+      )
+      |> assert_parses()
+
+    assert output =~ "rdr on lo0 inet proto tcp"
+    assert output =~ "-> 10.13.37.2 port #{@container_port}"
+  end
+
+  test "pfctl expands the network-interfaces macro" do
+    # The generated ruleset refers to $kleenet_network_interfaces; if the macro
+    # were missing or misspelled, pfctl would fail with "macro not defined".
+    output =
+      build(
+        networks: [network(interface: "lo0")],
+        containers: [
+          container_with_ports([
+            published_port(
+              interfaces: ["lo0"],
+              host_port: @host_port,
+              container_port: @container_port
+            )
+          ])
+        ]
+      )
+      |> assert_parses()
+
+    refute output =~ "$kleenet_network_interfaces"
+    assert output =~ "lo0"
+  end
+
+  test "a NAT'ed network produces a nat rule pf recognises" do
+    output =
+      build(networks: [network(interface: "lo0", nat: "lo0", subnet: "10.13.37.0/24")])
+      |> assert_parses()
+
+    assert output =~ "nat on lo0"
+  end
+
+  test "every icc/internal combination produces a loadable ruleset" do
+    for internal <- [true, false], icc <- [true, false], nat <- ["", "lo0"] do
+      config =
+        build(
+          networks: [network(interface: "lo0", internal: internal, icc: icc, nat: nat)],
+          host_gw: "lo0"
+        )
+
+      case pfctl_parse(config) do
+        {:ok, _} ->
+          :ok
+
+        {:error, output} ->
+          flunk(
+            "pfctl rejected internal=#{internal} icc=#{icc} nat=#{inspect(nat)}:\n" <>
+              "#{output}\n\nruleset was:\n#{config}"
+          )
+      end
+    end
+  end
+
+  test "IPv6 published ports produce a loadable ruleset" do
+    build(
+      containers: [
+        container_with_ports([
+          published_port(
+            interfaces: ["lo0"],
+            ip_address: "",
+            ip_address6: "fd00::2",
+            host_port: @host_port,
+            container_port: @container_port
+          )
+        ])
+      ]
+    )
+    |> assert_parses()
+  end
+
+  test "port ranges produce a loadable ruleset" do
+    output =
+      build(
+        containers: [
+          container_with_ports([
+            published_port(
+              interfaces: ["lo0"],
+              host_port: "15080:15090",
+              container_port: "16080:*"
+            )
+          ])
+        ]
+      )
+      |> assert_parses()
+
+    assert output =~ "16080"
+  end
+
+  test "the check has teeth: a corrupted ruleset is rejected" do
+    # Guards against these tests passing vacuously -- if pfctl accepted anything,
+    # everything above would be worthless.
+    config = build() <> "\nthis is not valid pf syntax\n"
+    assert {:error, output} = pfctl_parse(config)
+    assert output =~ "syntax error"
+  end
+
+  test "the check has teeth: an undefined macro is rejected" do
+    config = build() <> "\npass quick on $no_such_macro all\n"
+    assert {:error, _output} = pfctl_parse(config)
+  end
+end

--- a/test/utils/pf_fixtures.ex
+++ b/test/utils/pf_fixtures.ex
@@ -1,0 +1,92 @@
+defmodule Kleened.Test.PfFixtures do
+  @moduledoc """
+  Builders for exercising `Kleened.Core.Network.build_pf_config/1`.
+
+  Shared by the generation tests (`pf_config_test.exs`, which assert on the
+  rendered text) and the load tests (`pf_load_test.exs`, which feed the result to
+  `pfctl -n -f` and assert on what pf itself parses).
+  """
+
+  alias Kleened.Core.Network
+  alias Kleened.API.Schemas
+
+  @doc """
+  A copy of `example/pf.conf.kleene`'s placeholders.
+
+  Kept inline rather than read from disk so the tests do not depend on a file a
+  developer may have edited, and so they stay in the unprivileged tier.
+  """
+  def template do
+    """
+    ### KLEENED MACROS START ###
+    <%= kleene_macros %>
+    ### KLEENED MACROS END #####
+
+    ### KLEENED TRANSLATION RULES START ###
+    <%= kleene_translation %>
+    ### KLEENED TRANSLATION RULES END #####
+
+    ### KLEENED FILTERING RULES START #####
+    <%= kleene_filtering %>
+    ### KLEENED FILTERING RULES END #######
+    """
+  end
+
+  @doc "Render a pf config from the given overrides, defaulting everything else."
+  def build(opts \\ []) do
+    Network.build_pf_config(%{
+      networks: Keyword.get(opts, :networks, []),
+      network_endpoints: Keyword.get(opts, :network_endpoints, %{}),
+      containers: Keyword.get(opts, :containers, []),
+      host_gateway: Keyword.get(opts, :host_gateway, "em0"),
+      host_gw: Keyword.get(opts, :host_gw, "em0"),
+      template: Keyword.get(opts, :template, template())
+    })
+  end
+
+  def network(attrs \\ []) do
+    struct!(
+      %Schemas.Network{
+        id: "netid",
+        name: "testnet",
+        type: "loopback",
+        interface: "kleene0",
+        subnet: "10.13.37.0/24",
+        subnet6: "",
+        gateway: "",
+        gateway6: "",
+        nat: "",
+        icc: true,
+        internal: false
+      },
+      attrs
+    )
+  end
+
+  def container_with_ports(pub_ports) do
+    %Schemas.Container{id: "conid", name: "testcon", public_ports: pub_ports}
+  end
+
+  def published_port(attrs \\ []) do
+    struct!(
+      %Schemas.PublishedPort{
+        interfaces: ["em0"],
+        host_port: "8080",
+        container_port: "80",
+        protocol: "tcp",
+        ip_address: "10.13.37.2",
+        ip_address6: ""
+      },
+      attrs
+    )
+  end
+
+  @doc """
+  Body of one of the template's sections, e.g. "TRANSLATION" or "FILTERING".
+  """
+  def section(config, name) do
+    [_before, rest] = String.split(config, "### KLEENED #{name}", parts: 2)
+    [body, _after] = String.split(rest, "### KLEENED #{name}", parts: 2)
+    body |> String.split("\n", parts: 2) |> List.last()
+  end
+end


### PR DESCRIPTION
Builds on [#12](https://github.com/kleene-project/kleened/pull/12). That PR asserts on the text Kleene produces — which only proves the generator agrees with *our* idea of pf syntax.

These tests hand that text to `pfctl -n -v -f`, which parses it and prints the ruleset **pf constructed**, without loading anything into the kernel:

```
$ pfctl -n -v -f generated.conf
ext_if = "lo0"
rdr on lo0 inet proto tcp from any to (lo0) port = http-alt -> 10.13.37.2 port 80
pass quick on lo0 inet proto tcp from any to 10.13.37.2 port = http flags S/SA keep state
```

Macros expanded, ports canonicalised, pf's implicit `flags S/SA keep state` filled in. This directly answers your point that generating a config and string-matching it is just a validator's opinion — it isn't our opinion here, it's pf's.

Needs root (pfctl opens a netlink socket) but nothing else: no jails, no ZFS, no containers, no daemon. **Nine tests in 0.08 s.** Two of them assert that a corrupted ruleset and an undefined macro are *rejected*, so the suite can't pass vacuously.

## The bug it found immediately

A container's published ports always generate a filter rule referencing `$kleenet_network_interfaces`, but the macro was only emitted when at least one network existed:

```
/tmp/kleene_pf_test_37:11: macro 'kleenet_network_interfaces' not defined
```

Publishing a port with no networks defined produced a ruleset pf **refuses in full** — so the config fails to load and the previous ruleset silently stays in place. `network_interfaces_macro/1` now always defines it, falling back to `"{lo0}"`.

Nothing in the existing suite could have caught this. It's invisible to the generation tests, and every connectivity test has a network by construction.

## Also

- icc/internal assertions strengthened from "the rules differ" to naming the specific rules each flag contributes (`icc` → the subnet-to-subnet pass rule; `internal` → the two egress blocks), plus a test that the two flags are independent.
- Shared builders extracted to `Kleened.Test.PfFixtures`, used by both files.

```
make test-unit    30 tests, 0.6s
make test        172 tests, 0 failures
```

## What I have not done, and why

The plan also said to shrink the combinatorial part of the connectivity matrix, keeping representative cells. **I've left that out and would like your call first.**

Rung B proves a ruleset *loads*; it does not prove it *behaves*. So it isn't a like-for-like replacement for a test that boots two containers and checks a packet was actually blocked — and those are the tests you were explicitly protective of, for good reason.

What this PR does is make the reduction *arguable*: the per-combination rules are now pinned precisely, so a cell that differs only in generated rules is genuinely covered at rungs A and B. My suggestion would be to drop the cells in `network_test.exs:1182-1421` that vary only by icc/internal/published-port combination while keeping one per driver, one blocked case and one published-port case — but that is a judgement about how much behavioural evidence you want, not something I should decide unilaterally. Happy to do it as a follow-up if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)