### PR TITLE
Stage 4a: move per-test setup and cleanup into Kleene.Test.ConnCase

### DIFF
--- a/test/container_test.exs
+++ b/test/container_test.exs
@@ -1,25 +1,9 @@
 defmodule ContainerTest do
-  require Logger
   use Kleened.Test.ConnCase
-  alias ExUnit.CaptureLog
   alias Kleened.Core.{Container, Exec, MetaData, OS}
   alias Kleened.API.Schemas
 
   @moduletag :capture_log
-
-  setup %{host_state: state} do
-    TestHelper.cleanup()
-
-    on_exit(fn ->
-      CaptureLog.capture_log(fn ->
-        Logger.info("Cleaning up after test...")
-        TestHelper.cleanup()
-        TestHelper.compare_to_baseline_environment(state)
-      end)
-    end)
-
-    :ok
-  end
 
   test "start a container with environment variables" do
     dockerfile = """

--- a/test/exec_test.exs
+++ b/test/exec_test.exs
@@ -1,5 +1,4 @@
 defmodule ExecTest do
-  require Logger
   use Kleened.Test.ConnCase
   alias Kleened.Core.{Container, Exec, Utils, Network}
   alias Kleened.API.Schemas
@@ -7,9 +6,9 @@ defmodule ExecTest do
 
   @moduletag :capture_log
 
+  # Cleanup and the baseline check come from Kleened.Test.ConnCase; this only adds
+  # the network the exec tests attach their containers to.
   setup do
-    TestHelper.cleanup()
-
     {:ok, %Schemas.Network{name: "default"}} =
       Network.create(%Schemas.NetworkConfig{
         name: "default",
@@ -17,11 +16,6 @@ defmodule ExecTest do
         interface: "kleene1",
         type: "loopback"
       })
-
-    on_exit(fn ->
-      Logger.info("Cleaning up after test...")
-      TestHelper.cleanup()
-    end)
 
     :ok
   end

--- a/test/image_test.exs
+++ b/test/image_test.exs
@@ -1,26 +1,10 @@
 defmodule ImageTest do
   use Kleened.Test.ConnCase
-  alias ExUnit.CaptureLog
   alias Kleened.Core.{Config, MetaData, ZFS, OS, Container, FreeBSD}
   alias Kleened.API.Schemas
   alias Schemas.WebSocketMessage, as: Message
 
-  require Logger
   @moduletag :capture_log
-
-  setup %{host_state: state} do
-    TestHelper.cleanup()
-
-    on_exit(fn ->
-      CaptureLog.capture_log(fn ->
-        Logger.info("Cleaning up after test...")
-        TestHelper.cleanup()
-        TestHelper.compare_to_baseline_environment(state)
-      end)
-    end)
-
-    :ok
-  end
 
   @tmp_dockerfile "tmp_dockerfile"
   @tmp_context "./"

--- a/test/metadata_test.exs
+++ b/test/metadata_test.exs
@@ -1,5 +1,4 @@
 defmodule MetaDataTest do
-  require Logger
   use Kleened.Test.ConnCase
   alias Kleened.Core.Config
   alias Kleened.API.Schemas
@@ -7,18 +6,6 @@ defmodule MetaDataTest do
   import TestHelper, only: [now: 0]
 
   @moduletag :capture_log
-
-  setup %{host_state: state} do
-    TestHelper.cleanup()
-
-    on_exit(fn ->
-      Logger.info("Cleaning up after test...")
-      TestHelper.cleanup()
-      TestHelper.compare_to_baseline_environment(state)
-    end)
-
-    :ok
-  end
 
   test "adding, listing and removing networks" do
     assert [] == list_networks()

--- a/test/network_test.exs
+++ b/test/network_test.exs
@@ -1,6 +1,5 @@
 defmodule NetworkTest do
   use Kleened.Test.ConnCase
-  alias ExUnit.CaptureLog
   require Logger
   alias Kleened.Core.{Network, MetaData, OS}
   alias Kleened.Core.Utils.CIDR
@@ -22,18 +21,6 @@ defmodule NetworkTest do
   @cant_connect_disabled_with_any %{
     message: "containers with the 'disabled' network-driver cannot connect to networks."
   }
-  setup do
-    TestHelper.cleanup()
-
-    on_exit(fn ->
-      CaptureLog.capture_log(fn ->
-        TestHelper.cleanup()
-      end)
-    end)
-
-    :ok
-  end
-
   test "create, inspect, connect, and remove a 'loopback' network with custom interface name", %{
     api_spec: api_spec
   } do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,59 +34,10 @@ defmodule TestHelper do
   @kleened_host "/var/run/kleened.sock"
   @opts Router.init([])
 
-  def compare_to_baseline_environment(%{
-        addresses: before_addresses,
-        mount_devfs: before_mount_devfs
-      }) do
-    %{
-      addresses: after_addresses,
-      mount_devfs: after_mount_devfs,
-      datasets: after_datasets
-    } = Kleened.Test.Utils.get_host_state()
-
-    %Schemas.Image{dataset: test_dataset} = MetaData.get_image("FreeBSD:testing")
-
-    before_datasets =
-      MapSet.new([
-        test_dataset,
-        "",
-        "zroot/kleene",
-        "zroot/kleene/container",
-        "zroot/kleene/image",
-        "zroot/kleene/volumes"
-      ])
-
-    assert before_addresses == after_addresses
-    assert before_mount_devfs == after_mount_devfs
-
-    assert before_datasets == after_datasets
-  end
-
-  def cleanup() do
-    runnning_containers = Container.list(all: false)
-
-    case length(runnning_containers) do
-      0 ->
-        :ok
-
-      _ ->
-        runnning_containers |> Enum.map(fn %{id: id} -> Container.stop(id) end)
-
-        :timer.sleep(500)
-    end
-
-    MetaData.list_containers() |> Enum.map(fn %{id: id} -> Container.remove(id) end)
-
-    MetaData.list_volumes() |> Enum.map(&Volume.remove(&1.name))
-
-    MetaData.list_networks() |> Enum.map(fn %{id: id} -> Network.remove(id) end)
-
-    MetaData.list_images()
-    |> Enum.filter(fn image ->
-      not (image.name == "FreeBSD" and image.tag == "testing")
-    end)
-    |> Enum.map(fn image -> Image.remove(image.id) end)
-  end
+  # 'cleanup/0' and 'compare_to_baseline_environment/1' moved to
+  # 'Kleened.Test.Utils', where 'Kleened.Test.ConnCase' can reach them. Tests do
+  # not call them directly any more -- ConnCase does it for every test.
+  defdelegate cleanup(), to: Kleened.Test.Utils
 
   def container_valid_run(config) do
     {container_id, exec_config, expected_exit} = prepare_container_run(config)

--- a/test/utils/kleene_testcase.ex
+++ b/test/utils/kleene_testcase.ex
@@ -1,5 +1,23 @@
 defmodule Kleened.Test.ConnCase do
+  @moduledoc """
+  Shared case template for the tests that need a running daemon.
+
+  Every test starts from a clean host and leaves one behind: `cleanup/0` removes
+  all containers, volumes, networks and images (except the `FreeBSD:testing`
+  base image) before the test runs and again when it exits.
+
+  After the trailing cleanup, the host is compared against the snapshot taken
+  before the test. What that catches is the residue cleanup *cannot* remove -- a
+  leaked jail, an interface that was never destroyed, a devfs mount left behind
+  -- so the test that caused the leak is the one that fails, rather than some
+  unrelated test later in the run.
+
+  `network_test.exs` and `exec_test.exs` used to skip the baseline check because
+  their hand-written setup blocks never had it; they pass with it enabled.
+  """
   use ExUnit.CaseTemplate
+
+  require Logger
 
   using do
     quote do
@@ -15,6 +33,16 @@ defmodule Kleened.Test.ConnCase do
     api_spec = Kleened.API.Spec.spec()
 
     state = Kleened.Test.Utils.get_host_state()
+    Kleened.Test.Utils.cleanup()
+
+    on_exit(fn ->
+      ExUnit.CaptureLog.capture_log(fn ->
+        Logger.info("Cleaning up after test...")
+        Kleened.Test.Utils.cleanup()
+        Kleened.Test.Utils.compare_to_baseline_environment(state)
+      end)
+    end)
+
     {:ok, api_spec: api_spec, host_state: state}
   end
 end

--- a/test/utils/tools.ex
+++ b/test/utils/tools.ex
@@ -1,5 +1,6 @@
 defmodule Kleened.Test.Utils do
-  alias Kleened.Core.{Config, MetaData, Container, Image, ImageCreate, OS, ZFS}
+  import ExUnit.Assertions
+  alias Kleened.Core.{Config, MetaData, Container, Image, ImageCreate, Network, OS, Volume, ZFS}
   alias Kleened.API.Schemas
   require Logger
 
@@ -37,6 +38,75 @@ defmodule Kleened.Test.Utils do
       datasets: datasets,
       test_image_dataset: test_image_dataset
     }
+  end
+
+  @doc """
+  Remove everything Kleene owns, except the `FreeBSD:testing` base image.
+
+  Lives here rather than in `TestHelper` so that `Kleened.Test.ConnCase` -- which
+  is compiled, unlike `test_helper.exs` -- can call it without a compile-time
+  warning about an undefined module.
+  """
+  def cleanup() do
+    runnning_containers = Container.list(all: false)
+
+    case length(runnning_containers) do
+      0 ->
+        :ok
+
+      _ ->
+        runnning_containers |> Enum.map(fn %{id: id} -> Container.stop(id) end)
+
+        :timer.sleep(500)
+    end
+
+    MetaData.list_containers() |> Enum.map(fn %{id: id} -> Container.remove(id) end)
+
+    MetaData.list_volumes() |> Enum.map(&Volume.remove(&1.name))
+
+    MetaData.list_networks() |> Enum.map(fn %{id: id} -> Network.remove(id) end)
+
+    MetaData.list_images()
+    |> Enum.filter(fn image ->
+      not (image.name == "FreeBSD" and image.tag == "testing")
+    end)
+    |> Enum.map(fn image -> Image.remove(image.id) end)
+  end
+
+  @doc """
+  Assert that the host is back to the state captured by `get_host_state/0`.
+
+  Run *after* `cleanup/0`, so what it catches is the residue cleanup cannot
+  remove: a leaked jail, an interface that was never destroyed, a devfs mount
+  left behind. Those would otherwise surface as an unrelated failure much later
+  in the run.
+  """
+  def compare_to_baseline_environment(%{
+        addresses: before_addresses,
+        mount_devfs: before_mount_devfs
+      }) do
+    %{
+      addresses: after_addresses,
+      mount_devfs: after_mount_devfs,
+      datasets: after_datasets
+    } = get_host_state()
+
+    %Schemas.Image{dataset: test_dataset} = MetaData.get_image("FreeBSD:testing")
+
+    before_datasets =
+      MapSet.new([
+        test_dataset,
+        "",
+        "zroot/kleene",
+        "zroot/kleene/container",
+        "zroot/kleene/image",
+        "zroot/kleene/volumes"
+      ])
+
+    assert before_addresses == after_addresses
+    assert before_mount_devfs == after_mount_devfs
+
+    assert before_datasets == after_datasets
   end
 
   defp list_host_addresses() do

--- a/test/volume_test.exs
+++ b/test/volume_test.exs
@@ -1,26 +1,10 @@
 defmodule VolumeTest do
-  require Logger
   use Kleened.Test.ConnCase
-  alias ExUnit.CaptureLog
 
   alias Kleened.Core.{MetaData, Container, Volume, Mount}
   alias Kleened.API.Schemas
 
   @moduletag :capture_log
-
-  setup %{host_state: state} do
-    TestHelper.cleanup()
-
-    on_exit(fn ->
-      CaptureLog.capture_log(fn ->
-        Logger.info("Cleaning up after test...")
-        TestHelper.compare_to_baseline_environment(state)
-        TestHelper.cleanup()
-      end)
-    end)
-
-    :ok
-  end
 
   test "test filesystem operations when creating and deleting volumes", %{
     api_spec: api_spec


### PR DESCRIPTION
Part of the staged testing refactor. Stage 4 is "dedup and consolidate"; this is the kleened setup half of it. The deletions of duplicated cases come in a separate PR, once the klee side has landed.

## What was wrong

Six test modules each carried their own copy of the same `setup` block, and the copies had drifted:

| module | order | logs captured | baseline check |
|---|---|---|---|
| `container_test.exs` | cleanup → compare | yes | yes |
| `image_test.exs` | cleanup → compare | yes | yes |
| `metadata_test.exs` | cleanup → compare | **no** | yes |
| `volume_test.exs` | **compare → cleanup** | yes | yes |
| `exec_test.exs` | cleanup only | no | **no** |
| `network_test.exs` | cleanup only | yes | **no** |

`compare_to_baseline_environment/1` is what catches a leaked jail, an interface that was never destroyed or a devfs mount left behind — the failures that otherwise surface much later, in an unrelated test. Two modules skipped it, and `volume_test.exs` ran it before cleanup, which checks something else entirely.

## What this does

`Kleene.Test.ConnCase` now owns the whole lifecycle: snapshot the host, clean it, run the test, clean it again, compare against the snapshot. The six `setup` blocks are gone; `exec_test.exs` keeps a three-line `setup` for the network its containers attach to.

**`network_test.exs` and `exec_test.exs` pass with the baseline comparison enabled.** They were never opted out on purpose — their hand-written setup blocks just never had it. `network_test.exs` is the module most likely to leak an interface, so this is the one that most wanted checking.

`cleanup/0` and `compare_to_baseline_environment/1` move from `test_helper.exs` to `Kleened.Test.Utils`. ConnCase lives in `test/utils`, which *is* in `elixirc_paths`, so calling `TestHelper` (defined in the un-compiled `test_helper.exs`) from it would warn about an undefined module.

## Verification

`make test` — **172 tests, 0 failures**, unchanged from `main`, now with the baseline check running on 31 more tests than before.